### PR TITLE
fix: UpdateManyToMany should allow omission of sort order in join table

### DIFF
--- a/src/modules/interfaces/update-many-to-many-associations-options.interface.ts
+++ b/src/modules/interfaces/update-many-to-many-associations-options.interface.ts
@@ -1,9 +1,10 @@
 import { Transaction } from 'sequelize';
+import { CreatedByEntity } from '../models';
 import { JoinTableEntity } from '../models/join-table.entity';
 
 export interface UpdateManyToManyAssociationsOptions {
     parentInstanceId: number;
-    joinTableModel: typeof JoinTableEntity;
+    joinTableModel: typeof JoinTableEntity | typeof CreatedByEntity;
     parentForeignKey: string;
     childForeignKey: string;
     newChildren: any[];

--- a/src/modules/utils/update-many-to-many-associations.util.ts
+++ b/src/modules/utils/update-many-to-many-associations.util.ts
@@ -56,7 +56,7 @@ export async function updateManyToManyAssociations(
 
             // update sort order if necessary
             if (hasSortOrder) {
-                relationObjects[relationObjectIndex].sortOrder = i;
+                (relationObjects[relationObjectIndex] as JoinTableEntity).sortOrder = i;
                 relationObjects[relationObjectIndex].updatedById = updatingUserId;
                 promises.push(relationObjects[relationObjectIndex].save({ transaction }));
             }


### PR DESCRIPTION
#### Short description of what this resolves:
Updates types for UpdateManyToManyAssociationsOptions to appropriately allow the omission of sort order on the join table.

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README


#### Changes proposed in this pull request:
In order to allow the omission of the `sortOrder` on the `joinTableModel`, a type with out that property entirely (not one with just a type that has an optional sortOrder property) must be allowed.  For this reason, the type of  `joinTableModel` should be:
```typescript
 joinTableModel: typeof JoinTableEntity | typeof CreatedByEntity;
```

Later on, when the option `hasSortOrder` has been passed, that should be a clear enough signal that `joinTableModel` does have a `sortOrder` so we cast that appropriately.

**[JIRA Task Link:](https://maestro.atlassian.net/browse/HIVE-13?atlOrigin=eyJpIjoiYWNjNDJiNDE1Yzg3NDg4OGE1YWYxOWNlYzY0MDIwMWIiLCJwIjoiaiJ9)**