### PR TITLE
feat(types): Adds SequelizeFunctionType and deprecates SequelizeDate

### DIFF
--- a/src/modules/types/index.ts
+++ b/src/modules/types/index.ts
@@ -1,3 +1,4 @@
 export * from './diff.type';
 export * from './global-code-id.type';
 export * from './sequelize-date.type';
+export * from './sequelize-function-type.type';

--- a/src/modules/types/sequelize-date.type.ts
+++ b/src/modules/types/sequelize-date.type.ts
@@ -1,3 +1,6 @@
 import { Fn } from 'sequelize/types/lib/utils';
 
+/**
+ * @deprecated Use SequelizeFunctionType<Date> instead
+ */
 export type SequelizeDate = Date | Fn;

--- a/src/modules/types/sequelize-function-type.type.ts
+++ b/src/modules/types/sequelize-function-type.type.ts
@@ -1,0 +1,3 @@
+import { Fn } from 'sequelize/types/lib/utils';
+
+export type SequelizeFunctionType<T> = T | Fn;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
         "declaration": true,
         "moduleResolution": "node",
         "noUnusedLocals": true,
-        "removeComments": true
+        "removeComments": false
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
#### Short description of what this resolves:
Adds SequelizeFunctionType to use when a property will receive a function or a normal type.

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README

#### Changes proposed in this pull request:
- Creates SequelizeFunctionType
- Deprecates SequelizeDate