### PR TITLE
refactor: update-m2m requires that joinTableModel matches generic

### DIFF
--- a/src/modules/interfaces/update-many-to-many-associations-options.interface.ts
+++ b/src/modules/interfaces/update-many-to-many-associations-options.interface.ts
@@ -1,11 +1,12 @@
 import { Transaction } from 'sequelize';
+import { ModelCtor } from 'sequelize-typescript';
 import { CreatedByEntity } from '../models/created-by.entity';
 import { JoinTableEntity } from '../models/join-table.entity';
 import { AttributesOf } from '../types';
 
-export interface UpdateManyToManyAssociationsOptions<T> {
+export interface UpdateManyToManyAssociationsOptions<T extends JoinTableEntity | CreatedByEntity<T>> {
     parentInstanceId: number;
-    joinTableModel: typeof JoinTableEntity | typeof CreatedByEntity;
+    joinTableModel: ModelCtor<T>;
     parentForeignKey: keyof AttributesOf<T>;
     childForeignKey: keyof AttributesOf<T>;
     newChildren: any[];


### PR DESCRIPTION
#### Short description of what this resolves:
UpdateManyToManyOptions will now require that the joinTableModel matches what was given as the function's generic.

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README

#### Changes proposed in this pull request:
- Uses a stricter generic type in UpdateManyToMany and it's options
- joinTableModel must match the generic passed in.