### PR TITLE
chore: update to sequelize-typescript 1.0.0 and other dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,15 +31,15 @@
             "dev": true
         },
         "@types/node": {
-            "version": "12.7.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
-            "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
+            "version": "12.7.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
+            "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==",
             "dev": true
         },
         "@types/validator": {
-            "version": "10.11.2",
-            "resolved": "https://registry.npmjs.org/@types/validator/-/validator-10.11.2.tgz",
-            "integrity": "sha512-k/ju1RsdP5ACFUWebqsyEy0avP5uNJCs2p3pmTHzOZdd4gMSAJTq7iUEHFY3tt3emBrPTm6oGvfZ4SzcqOgLPQ==",
+            "version": "10.11.3",
+            "resolved": "https://registry.npmjs.org/@types/validator/-/validator-10.11.3.tgz",
+            "integrity": "sha512-GKF2VnEkMmEeEGvoo03ocrP9ySMuX1ypKazIYMlsjfslfBMhOAtC5dmEWKdJioW4lJN7MZRS88kalTsVClyQ9w==",
             "dev": true
         },
         "ansi-styles": {
@@ -224,9 +224,9 @@
             }
         },
         "inherits": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
         "is-bluebird": {
@@ -313,7 +313,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
@@ -354,9 +354,9 @@
             "dev": true
         },
         "sequelize": {
-            "version": "5.15.0",
-            "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.15.0.tgz",
-            "integrity": "sha512-w0jS4dcwLblIo284Yotb96noYrn6PUO92NtCE3VTDZxUgknfJZXfsbpsz+GqhIoE6gW1b8fsppwvk8fQTIPrlA==",
+            "version": "5.18.1",
+            "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.18.1.tgz",
+            "integrity": "sha512-jngo7pqilyOycMv6ZEwHLVn2wuHi/xkSQZfwK4jhjG8ta1HWYJK3XyQDFdhVEOH1GEq9pnqaf+7Kwqm+eqXD9Q==",
             "dev": true,
             "requires": {
                 "bluebird": "^3.5.0",
@@ -383,9 +383,9 @@
             "dev": true
         },
         "sequelize-typescript": {
-            "version": "1.0.0-beta.4",
-            "resolved": "https://registry.npmjs.org/sequelize-typescript/-/sequelize-typescript-1.0.0-beta.4.tgz",
-            "integrity": "sha512-aCtLX2Y453r+DEGMSgfyXrAibyCT1JYNOdNZ3g+banGgH0SqLHlBX4ZnFci5MC/2kxPMqXEAmlVdhecXG2szSQ==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/sequelize-typescript/-/sequelize-typescript-1.0.0.tgz",
+            "integrity": "sha512-oXyvHRTOyI8sJettpISL5LO30GaMMrLqzxiLCy6MjUmBJdaQDpdjn7ofge4J87MSdw+YPzkjrJLogMc9ONY2Tg==",
             "dev": true,
             "requires": {
                 "glob": "7.1.2"
@@ -425,9 +425,9 @@
             "dev": true
         },
         "tslint": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.18.0.tgz",
-            "integrity": "sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.19.0.tgz",
+            "integrity": "sha512-1LwwtBxfRJZnUvoS9c0uj8XQtAnyhWr9KlNvDIdB+oXyT+VpsOAaEhEgKi1HrZ8rq0ki/AAnbGSv4KM6/AfVZw==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
@@ -463,15 +463,15 @@
             }
         },
         "typescript": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-            "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
+            "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
             "dev": true
         },
         "uuid": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+            "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
             "dev": true
         },
         "validator": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bugs": {
         "url": "https://github.com/TeamHive/sequelize-common/issues"
     },
+    "license": "ISC",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
         "watch": "tsc -w",
@@ -26,19 +27,17 @@
         "postpack": "rm *.d.ts && rm *.js && rm -Rf modules"
     },
     "peerDependencies": {
-        "sequelize": "^5.8.9",
-        "sequelize-typescript": "^1.0.0-beta.3",
-        "@types/bluebird": "^3.5.27",
-        "@types/validator": "^10.11.1",
+        "sequelize": "^5.18.1",
+        "sequelize-typescript": "^1.0.0",
         "reflect-metadata": "^0.1.13"
     },
     "devDependencies": {
         "@types/bluebird": "^3.5.27",
-        "@types/validator": "^10.11.2",
+        "@types/validator": "^10.11.3",
         "reflect-metadata": "^0.1.13",
-        "sequelize": "^5.15.0",
-        "sequelize-typescript": "^1.0.0-beta.3",
-        "tslint": "^5.18.0",
-        "typescript": "^3.5.3"
+        "sequelize": "^5.18.1",
+        "sequelize-typescript": "^1.0.0",
+        "tslint": "^5.19.0",
+        "typescript": "^3.6.2"
     }
 }

--- a/src/modules/decorators/register-entity/entity-registration.ts
+++ b/src/modules/decorators/register-entity/entity-registration.ts
@@ -1,9 +1,9 @@
-import { Model } from 'sequelize-typescript';
+import { ModelCtor } from 'sequelize-typescript';
 
 export class EntityRegistration {
-    private static models: (typeof Model)[] = [];
+    private static models: ModelCtor<any>[] = [];
 
-    static registerEntity(model: typeof Model) {
+    static registerEntity(model: ModelCtor<any>) {
         EntityRegistration.models.push(model);
     }
 

--- a/src/modules/decorators/register-entity/register-entity.decorator.ts
+++ b/src/modules/decorators/register-entity/register-entity.decorator.ts
@@ -1,9 +1,8 @@
-import { Model } from 'sequelize-typescript';
+import { ModelCtor } from 'sequelize-typescript';
 import { EntityRegistration } from './entity-registration';
 
-// tslint:disable-next-line: ban-types
 export function RegisterEntity(): ClassDecorator {
     return (target) => {
-        EntityRegistration.registerEntity(target as unknown as typeof Model);
+        EntityRegistration.registerEntity(target as unknown as ModelCtor<any>);
     };
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Updates sequelize-typescript to 1.0.0 and updates other dependencies

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README

#### Changes proposed in this pull request:
- Updates sequelize-typescript to 1.0.0
- Uses ModelCtor in RegisterEntity and EntityRegistration