### PR TITLE
feat(AttributesOf): AttributesOf recursively applies to model properties

### DIFF
--- a/src/modules/types/attributes-of.type.ts
+++ b/src/modules/types/attributes-of.type.ts
@@ -1,6 +1,9 @@
+import { Model } from 'sequelize-typescript';
 import { EmptyModel } from '../models';
 
 type IncludedModelAttributes = 'id' | 'createdAt' | 'updatedAt' | 'deletedAt';
 type PropertiesToOmit = Exclude<keyof EmptyModel, IncludedModelAttributes>;
 
-export type AttributesOf<T> = Partial<Omit<T, PropertiesToOmit>>;
+export declare type AttributesOf<T extends Model> = Omit<{
+    [P in keyof T]?: T[P] extends Model ? AttributesOf<T[P]> : T[P];
+}, PropertiesToOmit>;


### PR DESCRIPTION
#### Short description of what this resolves:
AttributesOf used to just make other models optional, but not change the type. Now model properties of another model are also AttributesOf<PropertyType>

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README

#### Changes proposed in this pull request:
- Attributes of uses a mapping type and a conditional type to recursively apply AttributesOf