### PR TITLE
feat(association): Allow for custom childPrimaryKey

### DIFF
--- a/src/modules/interfaces/update-many-to-many-associations-options.interface.ts
+++ b/src/modules/interfaces/update-many-to-many-associations-options.interface.ts
@@ -12,6 +12,7 @@ export interface UpdateManyToManyAssociationsOptions<T extends JoinTableEntity |
     childForeignKey: keyof AttributesOf<T>;
     newChildren: any[];
     updatingUserId: number;
+    childPrimaryKey?: string;
     transaction?: Transaction;
     hasSortOrder?: boolean;
     instanceSpecificJoinTableFields?: InstanceSpecificJoinTableField[];

--- a/src/modules/interfaces/update-one-to-many-associations-optioins.interface.ts
+++ b/src/modules/interfaces/update-one-to-many-associations-optioins.interface.ts
@@ -4,6 +4,7 @@ export interface UpdateOneToManyAssociationsOptions {
     currentChildren: any[];
     newChildren: any[];
     updatingUserId: number;
+    childPrimaryKey?: string;
     hasSortOrder?: boolean;
     transaction?: Transaction;
 }

--- a/src/modules/utils/update-many-to-many-associations.util.ts
+++ b/src/modules/utils/update-many-to-many-associations.util.ts
@@ -11,12 +11,12 @@ export async function updateManyToManyAssociations<T extends JoinTableEntity | C
         newChildren,
         updatingUserId,
         transaction,
+        childPrimaryKey = 'id',
         hasSortOrder,
         instanceSpecificJoinTableFields,
         additionalJoinTableCreateFields
     }: UpdateManyToManyAssociationsOptions<T>
 ) {
-
     // get the current join table objects
     const relationObjects = await joinTableModel.findAll({
         where: { [parentForeignKey]: parentInstanceId }
@@ -38,7 +38,7 @@ export async function updateManyToManyAssociations<T extends JoinTableEntity | C
 
     // loop through the newChildren to create relation if necessary
     for (let i = 0; i < newChildren.length; i += 1) {
-        const relationObjectIndex = relationIds.indexOf(newChildren[i].id);
+        const relationObjectIndex = relationIds.indexOf(newChildren[i][childPrimaryKey]);
 
         // if they don't exist in the current relations, create new relation
         if (relationObjectIndex === -1) {
@@ -57,7 +57,7 @@ export async function updateManyToManyAssociations<T extends JoinTableEntity | C
                 joinTableModel.create(
                     {
                         [parentForeignKey as string]: parentInstanceId,
-                        [childForeignKey as string]: newChildren[i].id,
+                        [childForeignKey as string]: newChildren[i][childPrimaryKey],
                         // if sortOrder field doesn't exist, sequelize will not attempt to insert this value, so no error
                         sortOrder: i,
                         createdById: updatingUserId,

--- a/src/modules/utils/update-one-to-many-associations.util.ts
+++ b/src/modules/utils/update-one-to-many-associations.util.ts
@@ -6,11 +6,12 @@ export async function updateOneToManyAssociations(
         newChildren,
         hasSortOrder,
         updatingUserId,
+        childPrimaryKey = 'id',
         transaction
     }: UpdateOneToManyAssociationsOptions
 ) {
     // map current objects to an array of ids
-    const currentChildrenIds = currentChildren.map(currentChild => currentChild.id);
+    const currentChildrenIds = currentChildren.map(currentChild => currentChild[childPrimaryKey]);
     // set of all the current indexes of currentChildren, will remove indexes that are in the newChildren,
     // then delete any that remain in the set
     const currentChildrenIndexesToDelete = new Set([...Array(currentChildren.length).keys()]);
@@ -27,7 +28,7 @@ export async function updateOneToManyAssociations(
             promises.push(newChildren[i].save({ transaction }));
         }
 
-        const currentChildIndex = currentChildrenIds.indexOf(newChildren[i].id);
+        const currentChildIndex = currentChildrenIds.indexOf(newChildren[i][childPrimaryKey]);
 
         // if new child exists in the current children, set that index to not be deleted
         if (currentChildIndex !== -1) {


### PR DESCRIPTION
#### Short description of what this resolves:
- allow for `childPrimaryKey` to be passed to update association functions to support case where child primary key is not `id`

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter ÷errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**