### PR TITLE
feat(update-many-to-many): support for comparison keys and child fields

### DIFF
--- a/src/modules/interfaces/update-many-to-many-associations-options.interface.ts
+++ b/src/modules/interfaces/update-many-to-many-associations-options.interface.ts
@@ -48,6 +48,12 @@ export interface UpdateManyToManyAssociationsOptions<
      */
     childComparisonKeys?: string[];
     /**
+     * Attributes to request from the database.  These are used when determining
+     * if the child exists and to what parent it is related.  Should be given
+     * if default scope does not include enough information.
+     */
+    joinTableFindAttributes?: string[];
+    /**
      * The transaction to run the update in
      */
     transaction?: Transaction;

--- a/src/modules/interfaces/update-many-to-many-associations-options.interface.ts
+++ b/src/modules/interfaces/update-many-to-many-associations-options.interface.ts
@@ -5,16 +5,62 @@ import { CreatedByEntity } from '../models/created-by.entity';
 import { JoinTableEntity } from '../models/join-table.entity';
 import { AttributesOf } from '../types';
 
-export interface UpdateManyToManyAssociationsOptions<T extends JoinTableEntity | CreatedByEntity<T>> {
+export interface UpdateManyToManyAssociationsOptions<
+    T extends JoinTableEntity | CreatedByEntity<T>
+> {
+    /**
+     * The id of the parent instance
+     */
     parentInstanceId: number;
+    /**
+     * The sequelize model to use as a join table
+     */
     joinTableModel: ModelCtor<T>;
+    /**
+     * The column name for foreign key on the join table for the parent
+     */
     parentForeignKey: keyof AttributesOf<T>;
+    /**
+     * The column name for the foreign on the join table for the child
+     */
     childForeignKey: keyof AttributesOf<T>;
+    /**
+     * The new child with the that has the parentForeignKey, childForeignKey,
+     * possibly sort order, and additional fields for the join table.
+     */
     newChildren: any[];
+    /**
+     * The user updating the association
+     */
     updatingUserId: number;
+    /**
+     * Fields that are created/updated in on the join table based on their
+     * values on the child.
+     */
+    childCreateOrUpdateFields?: string[];
+    /**
+     * The key on the children object to be used as the child primary key
+     */
     childPrimaryKey?: string;
+    /**
+     * The keys used to determine if the child is a duplicate or if it already exists.
+     * Useful when multiple properties on the child determine uniqueness.
+     */
+    childComparisonKeys?: string[];
+    /**
+     * The transaction to run the update in
+     */
     transaction?: Transaction;
+    /**
+     * If true, sort order will be examined and updated on the child
+     */
     hasSortOrder?: boolean;
+    /**
+     *
+     */
     instanceSpecificJoinTableFields?: InstanceSpecificJoinTableField[];
+    /**
+     * These fields will be added to all children objects when created.
+     */
     additionalJoinTableCreateFields?: any;
 }

--- a/src/modules/utils/update-many-to-many-associations.util.ts
+++ b/src/modules/utils/update-many-to-many-associations.util.ts
@@ -17,22 +17,19 @@ export async function updateManyToManyAssociations<
     instanceSpecificJoinTableFields,
     additionalJoinTableCreateFields,
     childComparisonKeys,
-    childCreateOrUpdateFields
+    childCreateOrUpdateFields,
+    joinTableFindAttributes
 }: UpdateManyToManyAssociationsOptions<T>) {
     if (!childComparisonKeys) {
         childComparisonKeys = [childPrimaryKey];
     }
     // get the current join table objects
     const relationObjects = await joinTableModel.findAll({
-        attributes: Array.isArray(childPrimaryKey)
-            ? childPrimaryKey
+        attributes: childCreateOrUpdateFields
+            ? joinTableFindAttributes
             : undefined,
         where: { [parentForeignKey]: parentInstanceId }
     });
-    // // map the objects to be an array of the child ids
-    // const relationIds = relationObjects.map(
-    //     object => object[childForeignKey as string]
-    // );
     // set of all the current relationObjects, will remove indexes that are in the newChildren,
     // then delete remaining and return at end
     const relationIndexesToDelete = new Set([

--- a/src/modules/utils/update-many-to-many-associations.util.ts
+++ b/src/modules/utils/update-many-to-many-associations.util.ts
@@ -12,7 +12,7 @@ export async function updateManyToManyAssociations<
     newChildren,
     updatingUserId,
     transaction,
-    childPrimaryKey = "id",
+    childPrimaryKey = 'id',
     hasSortOrder,
     instanceSpecificJoinTableFields,
     additionalJoinTableCreateFields,


### PR DESCRIPTION
#### Short description of what this resolves:
Update many to many did not support comparing existing children by multiple fields nor passing in additional fields per child for creation/update.

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [ ] Updated README

