### PR TITLE
Feat/upsert only

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "cSpell.words": [
+        "BIGINT",
+        "UUIDV",
+        "upsert"
+    ]
+}

--- a/src/modules/interfaces/update-one-to-many-associations-options.interface.ts
+++ b/src/modules/interfaces/update-one-to-many-associations-options.interface.ts
@@ -47,4 +47,10 @@ export interface UpdateOneToManyAssociationsOptions<
      * The transaction to run the update in
      */
     transaction: Transaction;
+    /**
+     * Default: False
+     * If true, this will prevent this function from deleting relationships that were not provided.
+     */
+    upsertOnly: boolean;
+
 }

--- a/src/modules/utils/get-attributes.util.ts
+++ b/src/modules/utils/get-attributes.util.ts
@@ -7,7 +7,7 @@ type IncludedModelAttributes = 'id' | 'createdAt' | 'updatedAt' | 'deletedAt';
 export type AttributesArray<T extends Model<T>> = Diff<keyof T, Diff<keyof EmptyModel, IncludedModelAttributes>>[];
 
 /**
- * Typecheck that makes sure input array is a custom attribute
+ * Type check that makes sure input array is a custom attribute
  * of T (an entity). The type is created by all keys of T
  * that do not exist in an empty sequelize model (Empty Model),
  * but including the IncludeModelAttributes.

--- a/src/modules/utils/update-one-to-many-associations.util.ts
+++ b/src/modules/utils/update-one-to-many-associations.util.ts
@@ -20,6 +20,9 @@ export async function updateOneToManyAssociations<
         childTableModel,
     } = options;
 
+    // Used to determine if we will actually delete items at the end
+    const upsertOnly = !!options.upsertOnly;
+
     const relationIdsToDelete = new Set(
         currentChildren.map(currentChild => currentChild.id)
     );
@@ -65,7 +68,7 @@ export async function updateOneToManyAssociations<
     // create a default promise that will return that 0 records were updated
     let deletePromise = new Promise<[number, T[]]>(resolve => resolve([0, []]));
     // delete those records
-    if (idsToDelete.length > 0) {
+    if (idsToDelete.length > 0 && !upsertOnly) {
         deletePromise = childTableModel.update({
             deletedById: user.id,
             deletedAt: fn('now')


### PR DESCRIPTION
#### Short description of what this resolves:
Supporting Upsert Only for the updatemanyToMany and updateOneToMany 

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**