### PR TITLE
feat(update-assoc): support async fill functions

### DIFF
--- a/src/modules/types/update-association-fill-function.type.ts
+++ b/src/modules/types/update-association-fill-function.type.ts
@@ -10,4 +10,4 @@ export type UpdateAssociationFillFunction<
     NewChildrenType = any>
     = (newChild: NewChildrenType, index: number, existingRecord: T, updateOptions:
         UpdateManyToManyAssociationsOptions<T, AuthenticatedUserType, NewChildrenType> |
-        UpdateOneToManyAssociationsOptions<T, AuthenticatedUserType, NewChildrenType>) => AttributesOf<T>;
+        UpdateOneToManyAssociationsOptions<T, AuthenticatedUserType, NewChildrenType>) => AttributesOf<T> | Promise<AttributesOf<T>>;

--- a/src/modules/utils/default-update-many-to-many-fill-function.util.ts
+++ b/src/modules/utils/default-update-many-to-many-fill-function.util.ts
@@ -1,10 +1,16 @@
 import { UpdateManyToManyAssociationsOptions } from '../interfaces';
 import { AuthenticatedUser } from '../interfaces/authenticated-user.interface';
-import { CreatedByEntity } from '../models';
+import { CreatedByEntity, JoinTableEntity } from '../models';
 import { AttributesOf } from '../types';
 import { UpdateAssociationFillFunction } from '../types/update-association-fill-function.type';
 
-export function defaultUpdateManyToManyFillFunction<T extends CreatedByEntity<T>>(childForeignKey: keyof AttributesOf<T>): UpdateAssociationFillFunction<T, AuthenticatedUser, any> {
+export type UpdateAssociationSynchronousFillFunction<
+    T extends JoinTableEntity | CreatedByEntity<T>,
+    AuthenticatedUserType extends AuthenticatedUser = AuthenticatedUser,
+    NewChildrenType = any
+    > = (...params: Parameters<UpdateAssociationFillFunction<T, AuthenticatedUserType, NewChildrenType>>) => AttributesOf<T>;
+
+export function defaultUpdateManyToManyFillFunction<T extends CreatedByEntity<T>>(childForeignKey: keyof AttributesOf<T>): UpdateAssociationSynchronousFillFunction<T, AuthenticatedUser, any> {
     return (newChild: CreatedByEntity<any>, _index: number, _existingRecord: T, updateOptions: UpdateManyToManyAssociationsOptions<T, AuthenticatedUser>) => {
         const { parentForeignKey, parentInstanceId } = updateOptions;
         const newJoinTableRecord: AttributesOf<T> = {

--- a/src/modules/utils/update-one-to-many-associations.util.ts
+++ b/src/modules/utils/update-one-to-many-associations.util.ts
@@ -38,7 +38,7 @@ export async function updateOneToManyAssociations<
 
         // if they don't exist in the current relations, create new relation
         if (relationObjectIndex < 0) {
-            const filledRecord = fillFunction(newChildren[i], i, undefined, options);
+            const filledRecord = await fillFunction(newChildren[i], i, undefined, options);
             filledRecord.createdById = user.id;
             filledRecord.updatedById = user.id;
             recordsToCreate.push(filledRecord);
@@ -49,7 +49,7 @@ export async function updateOneToManyAssociations<
             currentChildren.splice(relationObjectIndex, 1);
             relationIdsToDelete.delete(relatedObject.id);
 
-            const filledRecord = fillFunction(newChildren[i], i, relatedObject, options);
+            const filledRecord = await fillFunction(newChildren[i], i, relatedObject, options);
             filledRecord.updatedById = user.id;
             // update sort order if necessary
             updatePromises.push(


### PR DESCRIPTION
#### Short description of what this resolves:
- update async fill functions in update m2m and update 12m
- update default function to still return async result (avoids breaking change)

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [ ] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**