### PR TITLE
feat(pagination): add pagination classes with sequelize find options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,205 @@
                 "js-tokens": "^4.0.0"
             }
         },
+        "@nestjs/common": {
+            "version": "7.6.15",
+            "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-7.6.15.tgz",
+            "integrity": "sha512-H/3Nk7M02Fc4YN9St05i34gZKVuzE54gd5eXAX6WwisqU5fQ00kss1pYGbltjb2QGu3A/fpO1MdYEwOA18Z/VQ==",
+            "dev": true,
+            "requires": {
+                "axios": "0.21.1",
+                "iterare": "1.2.1",
+                "tslib": "2.1.0",
+                "uuid": "8.3.2"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+                    "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+                    "dev": true
+                }
+            }
+        },
+        "@nestjs/core": {
+            "version": "7.6.15",
+            "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-7.6.15.tgz",
+            "integrity": "sha512-8CrL/iY5Gt4HJfyDg1PgPalhT7tVRT643f2mGMgPum/P/e94uuwEYBNIgsMEVOJUrOAWZkNIN60uEf8JkH6GWw==",
+            "dev": true,
+            "requires": {
+                "@nuxtjs/opencollective": "0.3.2",
+                "fast-safe-stringify": "2.0.7",
+                "iterare": "1.2.1",
+                "object-hash": "2.1.1",
+                "path-to-regexp": "3.2.0",
+                "tslib": "2.1.0",
+                "uuid": "8.3.2"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+                    "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+                    "dev": true
+                }
+            }
+        },
+        "@nestjs/mapped-types": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-0.0.3.tgz",
+            "integrity": "sha512-PKxWOVaMyvj9/82afLpMZ/+Pb5JacCURRP/FY/tCDtsoS+MABeQGj2oqbtH4uQUiL4n+H0IigvQGHWQ1zPPknA==",
+            "dev": true
+        },
+        "@nestjs/microservices": {
+            "version": "7.6.15",
+            "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-7.6.15.tgz",
+            "integrity": "sha512-WwjNvnudta+YKQOVnzkJGAggME1a8LsnoBZDzorYi4kCFs+U53viRsoidQUBR4oDYIu3IKkJmB9OCStHrK4PTw==",
+            "dev": true,
+            "requires": {
+                "iterare": "1.2.1",
+                "json-socket": "0.3.0",
+                "tslib": "2.1.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+                    "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+                    "dev": true
+                }
+            }
+        },
+        "@nestjs/passport": {
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-7.1.5.tgz",
+            "integrity": "sha512-Hu9hPxTdBZA0C4GrWTsSflzwsJ99oAk9jqAwpcszdFNqfjMjkPGuCM9QsVZbBP2bE8fxrVrPsNOILS6puY8e/A==",
+            "dev": true
+        },
+        "@nestjs/testing": {
+            "version": "7.6.15",
+            "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-7.6.15.tgz",
+            "integrity": "sha512-AWr8stnRoS0yCU/EotAJKveYXm1XSB4ZT+ReqFDXhPyqC1ppOfU+zZuCjQlQHorMzidsVHsAstK5/rUsXnrZUQ==",
+            "dev": true,
+            "requires": {
+                "optional": "0.1.4",
+                "tslib": "2.1.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+                    "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+                    "dev": true
+                }
+            }
+        },
+        "@nuxtjs/opencollective": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@nuxtjs/opencollective/-/opencollective-0.3.2.tgz",
+            "integrity": "sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^4.1.0",
+                "consola": "^2.15.0",
+                "node-fetch": "^2.6.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@teamhive/nestjs-common": {
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/@teamhive/nestjs-common/-/nestjs-common-14.1.1.tgz",
+            "integrity": "sha512-DRG/QOgBrgVkIA4XPgMtNjSNNs+wU/j098HwlBpciO0r2gx22Ooe8V6i/UkLWUeWuViVAdRGtKKEyJ569Q1Rfg==",
+            "requires": {
+                "bluebird": "^3.5.5",
+                "raven": "^2.6",
+                "redis": "^2.8"
+            }
+        },
+        "@teamhive/nestjs-swagger": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@teamhive/nestjs-swagger/-/nestjs-swagger-4.6.0.tgz",
+            "integrity": "sha512-o7xyaEatGifGleLkIxtLF6hqH2RnnuY2qF/06CQ4sTSZCqHcgz3MjwTWQKhMVNguW5PvCo7+KBzVopSXQvyJZQ==",
+            "dev": true,
+            "requires": {
+                "@nestjs/mapped-types": "0.0.3",
+                "lodash": "4.17.15",
+                "path-to-regexp": "3.2.0"
+            }
+        },
+        "@teamhive/node-common": {
+            "version": "3.0.0-alpha.6",
+            "resolved": "https://registry.npmjs.org/@teamhive/node-common/-/node-common-3.0.0-alpha.6.tgz",
+            "integrity": "sha512-olnv3sgQbezip0V8gPpm8ET/WTvhyQkOBG4qvAmGKFHbb629uXlDLUL21IdQA+5axSpSNpVhf8Y62FpukoTtbQ==",
+            "dev": true,
+            "requires": {
+                "config": "^3.2.3",
+                "deepmerge": "^4.0.0",
+                "log4js": "^6.1.0",
+                "raven": "^2.6.4"
+            }
+        },
         "@types/bluebird": {
             "version": "3.5.27",
             "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.27.tgz",
@@ -75,6 +274,15 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "axios": {
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+            "dev": true,
+            "requires": {
+                "follow-redirects": "^1.10.0"
+            }
+        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -84,8 +292,7 @@
         "bluebird": {
             "version": "3.5.5",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-            "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
-            "dev": true
+            "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -112,6 +319,36 @@
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
+            }
+        },
+        "charenc": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+            "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+        },
+        "class-validator": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
+            "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
+            "dev": true,
+            "requires": {
+                "@types/validator": "^13.1.3",
+                "libphonenumber-js": "^1.9.7",
+                "validator": "^13.5.2"
+            },
+            "dependencies": {
+                "@types/validator": {
+                    "version": "13.1.3",
+                    "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.1.3.tgz",
+                    "integrity": "sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA==",
+                    "dev": true
+                },
+                "validator": {
+                    "version": "13.5.2",
+                    "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
+                    "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ==",
+                    "dev": true
+                }
             }
         },
         "cls-bluebird": {
@@ -151,6 +388,37 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
+        "config": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/config/-/config-3.3.6.tgz",
+            "integrity": "sha512-Hj5916C5HFawjYJat1epbyY2PlAgLpBtDUlr0MxGLgo3p5+7kylyvnRY18PqJHgnNWXcdd0eWDemT7eYWuFgwg==",
+            "dev": true,
+            "requires": {
+                "json5": "^2.1.1"
+            }
+        },
+        "consola": {
+            "version": "2.15.3",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
+            "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
+            "dev": true
+        },
+        "cookie": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        },
+        "crypt": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+            "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+        },
+        "date-format": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
+            "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==",
+            "dev": true
+        },
         "debug": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -177,6 +445,11 @@
             "integrity": "sha512-ch5OQgvGDK2u8pSZeSYAQaV/lczImd7pMJ7BcEPXmnFVjy4yJIzP6CsODJUTH8mg1tyH1Z2abOiuJO3DjZ/GBw==",
             "dev": true
         },
+        "double-ended-queue": {
+            "version": "2.1.0-0",
+            "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+            "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -194,6 +467,35 @@
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
+        },
+        "fast-safe-stringify": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+            "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+            "dev": true
+        },
+        "flatted": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+            "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+            "dev": true
+        },
+        "follow-redirects": {
+            "version": "1.13.3",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+            "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
+            "dev": true
+        },
+        "fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -214,6 +516,12 @@
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
             }
+        },
+        "graceful-fs": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+            "dev": true
         },
         "has-flag": {
             "version": "3.0.0",
@@ -249,6 +557,11 @@
             "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI=",
             "dev": true
         },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        },
         "is-plain-object": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
@@ -261,6 +574,12 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
             "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        },
+        "iterare": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
+            "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
+            "dev": true
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -278,11 +597,72 @@
                 "esprima": "^4.0.0"
             }
         },
+        "json-socket": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/json-socket/-/json-socket-0.3.0.tgz",
+            "integrity": "sha512-jc8ZbUnYIWdxERFWQKVgwSLkGSe+kyzvmYxwNaRgx/c8NNyuHes4UHnPM3LUrAFXUx1BhNJ94n1h/KCRlbvV0g==",
+            "dev": true
+        },
+        "json5": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+            "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.5"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                }
+            }
+        },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "libphonenumber-js": {
+            "version": "1.9.14",
+            "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.14.tgz",
+            "integrity": "sha512-lQEHej1NQwKwmn89ixSfvj+m7Gm6AsafuxU1BMsS22VUizQPnamVslA2d5wsHHaaXOExAvlcYjUF1C7ieTzoCg==",
+            "dev": true
+        },
         "lodash": {
             "version": "4.17.15",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
             "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
             "dev": true
+        },
+        "log4js": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
+            "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
+            "dev": true,
+            "requires": {
+                "date-format": "^3.0.0",
+                "debug": "^4.1.1",
+                "flatted": "^2.0.1",
+                "rfdc": "^1.1.4",
+                "streamroller": "^2.2.4"
+            }
+        },
+        "md5": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+            "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+            "requires": {
+                "charenc": "0.0.2",
+                "crypt": "0.0.2",
+                "is-buffer": "~1.1.6"
+            }
         },
         "minimatch": {
             "version": "3.0.4",
@@ -329,6 +709,18 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
+        "node-fetch": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+            "dev": true
+        },
+        "object-hash": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.1.1.tgz",
+            "integrity": "sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==",
+            "dev": true
+        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -338,9 +730,31 @@
                 "wrappy": "1"
             }
         },
+        "optional": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
+            "integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==",
+            "dev": true
+        },
+        "passport": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
+            "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+            "dev": true,
+            "requires": {
+                "passport-strategy": "1.x.x",
+                "pause": "0.0.1"
+            }
+        },
+        "passport-strategy": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+            "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ=",
+            "dev": true
+        },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
@@ -349,6 +763,57 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
             "dev": true
+        },
+        "path-to-regexp": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
+            "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==",
+            "dev": true
+        },
+        "pause": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+            "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=",
+            "dev": true
+        },
+        "raven": {
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
+            "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
+            "requires": {
+                "cookie": "0.3.1",
+                "md5": "^2.2.1",
+                "stack-trace": "0.0.10",
+                "timed-out": "4.0.1",
+                "uuid": "3.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "3.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+                }
+            }
+        },
+        "redis": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+            "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+            "requires": {
+                "double-ended-queue": "^2.1.0-0",
+                "redis-commands": "^1.2.0",
+                "redis-parser": "^2.6.0"
+            }
+        },
+        "redis-commands": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+            "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+        },
+        "redis-parser": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+            "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
         },
         "reflect-metadata": {
             "version": "0.1.13",
@@ -372,6 +837,21 @@
             "dev": true,
             "requires": {
                 "any-promise": "^1.3.0"
+            }
+        },
+        "rfdc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+            "dev": true
+        },
+        "rxjs": {
+            "version": "6.6.6",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
+            "integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.9.0"
             }
         },
         "semver": {
@@ -430,6 +910,30 @@
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+        },
+        "streamroller": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
+            "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
+            "dev": true,
+            "requires": {
+                "date-format": "^2.1.0",
+                "debug": "^4.1.1",
+                "fs-extra": "^8.1.0"
+            },
+            "dependencies": {
+                "date-format": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+                    "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
+                    "dev": true
+                }
+            }
+        },
         "supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -438,6 +942,11 @@
             "requires": {
                 "has-flag": "^3.0.0"
             }
+        },
+        "timed-out": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
         "toposort-class": {
             "version": "1.0.1",
@@ -493,6 +1002,12 @@
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
             "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
+            "dev": true
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true
         },
         "uuid": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
         "watch": "tsc -w",
         "start": "tsc",
         "postpublish": "git push && git push --tags",
-        "prepack": "tsc"
-        
+        "prepack": "tsc",
+        "postpack": "rm *.d.ts && rm *.js && rm -Rf modules"
     },
     "peerDependencies": {
         "@teamhive/nestjs-common": "^14.1.1",

--- a/package.json
+++ b/package.json
@@ -23,21 +23,35 @@
         "watch": "tsc -w",
         "start": "tsc",
         "postpublish": "git push && git push --tags",
-        "prepack": "tsc",
-        "postpack": "rm *.d.ts && rm *.js && rm -Rf modules"
+        "prepack": "tsc"
+        
     },
     "peerDependencies": {
+        "@teamhive/nestjs-common": "^14.1.1",
         "moment": "^2.25.3",
         "sequelize": "^5.18.1",
         "sequelize-typescript": "^1.0.0",
         "reflect-metadata": "^0.1.13"
     },
     "devDependencies": {
+        "@nestjs/common": "^7.6.15",
+        "@nestjs/core": "^7.6.15",
+        "@nestjs/microservices": "^7.6.15",
+        "@nestjs/passport": "^7.1.5",
+        "@nestjs/testing": "^7.6.15",
+        "@teamhive/nestjs-swagger": "^4.6.0",
+        "@teamhive/nestjs-common": "^14.1.1",
+        "@teamhive/node-common": "^3.0.0-alpha.6",
         "@types/bluebird": "^3.5.27",
         "@types/moment": "^2.13.0",
         "@types/validator": "^10.11.3",
+        "class-validator": "^0.13.1",
+        "config": "^3.3.6",
+        "log4js": "^6.3.0",
         "moment": "^2.25.3",
+        "passport": "^0.4.1",
         "reflect-metadata": "^0.1.13",
+        "rxjs": "^6.6.6",
         "sequelize": "^5.18.1",
         "sequelize-typescript": "^1.0.0",
         "tslint": "^5.19.0",
@@ -46,5 +60,10 @@
     "dependencies": {
         "deepmerge": "^4.2.2",
         "is-plain-object": "^3.0.0"
+    },
+    "peerDependenciesMeta": {
+        "@teamhive/nestjs-common": {
+            "optional": true
+        }
     }
 }

--- a/src/modules/dtos/index.ts
+++ b/src/modules/dtos/index.ts
@@ -1,0 +1,3 @@
+export * from './sequelize-filter.dto';
+export * from './sequelize-pagination-search.dto';
+export * from './sequelize-pagination.dto';

--- a/src/modules/dtos/sequelize-filter.dto.ts
+++ b/src/modules/dtos/sequelize-filter.dto.ts
@@ -1,0 +1,5 @@
+import { FindOptions } from 'sequelize/types';
+
+export abstract class SequelizeFilter {
+    protected abstract getFindOptions(findOptions?: FindOptions): FindOptions;
+}

--- a/src/modules/dtos/sequelize-pagination-search.dto.ts
+++ b/src/modules/dtos/sequelize-pagination-search.dto.ts
@@ -1,0 +1,13 @@
+import { PaginationSearch } from '@teamhive/nestjs-common';
+import { FindOptions } from 'sequelize/types';
+
+export class SequelizePaginationSearchDto extends PaginationSearch {
+    getFindOptions() {
+        const paginationFindOptions: FindOptions = {
+            include: this.search ? [this.search] : [],
+            limit: this.size,
+            offset: this.offset
+        };
+        return paginationFindOptions;
+    }
+}

--- a/src/modules/dtos/sequelize-pagination.dto.ts
+++ b/src/modules/dtos/sequelize-pagination.dto.ts
@@ -1,0 +1,12 @@
+import { Pagination } from '@teamhive/nestjs-common';
+import { FindOptions } from 'sequelize/types';
+
+export class SequelizePaginationDto extends Pagination {
+    getFindOptions() {
+        const paginationFindOptions: FindOptions = {
+            limit: this.size,
+            offset: this.offset
+        };
+        return paginationFindOptions;
+    }
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,5 +1,6 @@
 export * from './classes';
 export * from './decorators';
+export * from './dtos';
 export * from './interfaces';
 export * from './models';
 export * from './types';

--- a/src/modules/models/base-view.entity.ts
+++ b/src/modules/models/base-view.entity.ts
@@ -11,13 +11,13 @@ import { AttributesOf } from '../types/attributes-of.type';
 export class BaseViewEntity<i> extends Model<BaseViewEntity<i>> {
 
     static findOne<M extends BaseViewEntity<any>>(options: FindOptions): Sequelize.Promise<M> {
-        return new Sequelize.Promise((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             this.findAll(options).then(results => {
                 resolve((results && results.length > 0 ? results[0] : undefined) as any);
             }).catch(error => {
                 reject(error);
             });
-        });
+        }) as unknown as Sequelize.Promise<M>;
     }
 
     /**

--- a/src/modules/utils/fetch-all-response.util.ts
+++ b/src/modules/utils/fetch-all-response.util.ts
@@ -1,0 +1,23 @@
+import { FindAndCountAllResponse } from '../interfaces/find-and-count-all-response.interface';
+
+export function fetchAllResponse<T, AdditionalParams = any>(
+    response: FindAndCountAllResponse<T>,
+    responseClass: new (content: T, additionalParams?: AdditionalParams) => any,
+    additionalParamFunction?: (content: T) => AdditionalParams
+) {
+    const content = [];
+    if (response.rows && response.rows.length > 0) {
+        content.push(
+            ...response.rows.map((row) => {
+                const additionalParams: AdditionalParams = additionalParamFunction
+                    ? additionalParamFunction(row)
+                    : undefined;
+                return new responseClass(row, additionalParams);
+            })
+        );
+    }
+    return {
+        content,
+        totalElements: response.count
+    };
+}

--- a/src/modules/utils/index.ts
+++ b/src/modules/utils/index.ts
@@ -2,6 +2,7 @@ export * from './attach-table-name-to-column.util';
 export * from './attach-table-name-to-columns.util';
 export * from './default-update-association-comparison-function.util';
 export * from './default-update-many-to-many-fill-function.util';
+export * from './fetch-all-response.util';
 export * from './get-attributes.util';
 export * from './get-search-where-clause.util';
 export * from './merge-options.util';

--- a/src/modules/utils/merge-options.util.ts
+++ b/src/modules/utils/merge-options.util.ts
@@ -82,7 +82,8 @@ const getTransaction = (baseOptions: any, requestOptions: any) => {
 const attachTransaction = (mergedOptions: any, transaction: any) => {
     mergedOptions.transaction = transaction;
 };
-export const mergeOptions = (
+
+const _mergeOptions = (
     baseOptions: any = {},
     requestOptions: any = {}
 ): FindOptions => {
@@ -100,4 +101,20 @@ export const mergeOptions = (
     });
     attachTransaction(mergedOptions, transaction);
     return (mergedOptions as unknown) as FindOptions;
+};
+
+export const mergeOptions = (
+    ...options: any[]
+): FindOptions => {
+    if (options.length === 0) {
+        return {};
+    }
+    else {
+        let findOptions = options[0];
+        // merge all of the options together one by one
+        for(let i = 1; i < options.length; i++) {
+            findOptions = _mergeOptions(findOptions, options[i]);
+        }
+        return findOptions;
+    }
 };

--- a/src/modules/utils/update-one-to-many-associations.util.ts
+++ b/src/modules/utils/update-one-to-many-associations.util.ts
@@ -51,6 +51,11 @@ export async function updateOneToManyAssociations<
 
             const filledRecord = await fillFunction(newChildren[i], i, relatedObject, options);
             filledRecord.updatedById = user.id;
+
+            // if the record is being updated, ensure it is not deleted
+            filledRecord.deletedAt = null;
+            filledRecord.deletedById = null;
+            
             // update sort order if necessary
             updatePromises.push(
                 relatedObject.update(filledRecord, { transaction }) as unknown as Promise<T>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,11 @@
         "declaration": true,
         "moduleResolution": "node",
         "noUnusedLocals": true,
-        "removeComments": false
+        "removeComments": false,
+        "typeRoots": ["node_modules/@types"],
+        "types": ["node"],
+        "esModuleInterop": true,
+        "skipLibCheck": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
#### Short description of what this resolves:
- adds pagination classes to sequelize common that generate find options based on those pagination options
- nestjs common becomes an optional peer dependency. If you don't use these classes you don't need the dependency

### PR Checklist
- [ ] All `TODO`'s are done and removed
- [ ] `package.json` has correct information
- [ ] All dependencies are of correct type (regular vs peer vs dev)
- [ ] Documented any complicated or confusing code
- [ ] No linter errors
- [ ] Project packages successfully (`npm pack`)
- [ ] Installed local packed version in another project and tested
- [ ] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**