### PR TITLE
fix(pagination): apply order by in pagination dtos

### DIFF
--- a/src/modules/dtos/sequelize-pagination-search.dto.ts
+++ b/src/modules/dtos/sequelize-pagination-search.dto.ts
@@ -6,7 +6,8 @@ export class SequelizePaginationSearchDto extends PaginationSearch {
         const paginationFindOptions: FindOptions = {
             include: this.search ? [this.search] : [],
             limit: this.size,
-            offset: this.offset
+            offset: this.offset,
+            order: this.getOrderBy()
         };
         return paginationFindOptions;
     }


### PR DESCRIPTION
#### Short description of what this resolves:
- when applying find options for standard sequelize dtos, apply order as well as pagination options

### PR Checklist
- [ ] All `TODO`'s are done and removed
- [ ] `package.json` has correct information
- [ ] All dependencies are of correct type (regular vs peer vs dev)
- [ ] Documented any complicated or confusing code
- [ ] No linter errors
- [ ] Project packages successfully (`npm pack`)
- [ ] Installed local packed version in another project and tested
- [ ] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**